### PR TITLE
handle imports that dont resolve with css

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ You have a css string with `@import` statements, you want them resolved and inli
 Code mostly adapted from the css `@import` part of [inliner](https://github.com/remy/inliner).
 Recursively inlines css imports, so works for nested `@import`s too.
 
-**NOTE** still in development - use at own risk. :)
+Still relatively early days, use with caution.
 
 ## Requirements
 `Node@^0.12` (could use earlier version if you polyfilled `Promise`).
@@ -26,3 +26,6 @@ inlineCssImports(css, baseUrl)
   console.log('I have all css @imports inlined!', updatedCss)
 })
 ```
+
+## Note
+Will just remove `@import` for css that doesn't exist.

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,10 @@ var _cssFromImport = function _cssFromImport(importString, baseUrl) {
   return (0, _nodeFetch2['default'])(importUrl).then(function (response) {
     return response.text();
   }).then(function (importedCss) {
+    if (/^</.test(importedCss)) {
+      // ignore imports that resolve in something other than css (html, most likely)
+      return Promise.resolve('');
+    }
     importedCss = importedCss.replace(/\n$/, '');
 
     if (mediaTypes.length !== 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,10 @@ const _cssFromImport = function (importString, baseUrl) {
   return fetch(importUrl)
   .then(response => response.text())
   .then(importedCss => {
+    if (/^</.test(importedCss)) {
+      // ignore imports that resolve in something other than css (html, most likely)
+      return Promise.resolve('')
+    }
     importedCss = importedCss.replace(/\n$/, '')
 
     if (mediaTypes.length !== 0) {

--- a/test/fixtures/404.html
+++ b/test/fixtures/404.html
@@ -1,0 +1,11 @@
+<html>
+  <head>
+    <style>
+    /* some inline styles to confuse things */
+    body { color: red; }
+    </style>
+  </head>
+  <body>
+    Nothing here!
+  </body>
+</html>

--- a/test/fixtures/missing.css
+++ b/test/fixtures/missing.css
@@ -1,0 +1,1 @@
+@import url(404.html);

--- a/test/index.js
+++ b/test/index.js
@@ -21,9 +21,9 @@ const failTest = function (t) {
 const runImportTest = function (testLabel, cssFileName, expectedFileName) {
   test(testLabel, t => {
     const originalCss = fs.readFileSync(path.join(FIXTURES_DIR, cssFileName), 'utf8')
-    const expectedCss = fs.readFileSync(path.join(FIXTURES_DIR, expectedFileName), 'utf8')
+    const expectedCss = expectedFileName ? fs.readFileSync(path.join(FIXTURES_DIR, expectedFileName), 'utf8') : ''
     return inlineCssImports(originalCss, `http://localhost:${PORT}/${cssFileName}`)
-    .then(resultingCss => t.is(resultingCss, expectedCss))
+    .then(resultingCss => t.is(resultingCss.trim(), expectedCss.trim()))
     .catch(() => failTest(t))
   })
 }
@@ -34,4 +34,5 @@ server.on('listening', () => {
   runImportTest('basic', 'basic.css', 'reset.css')
   runImportTest('core', 'core.css', 'core--result.css')
   runImportTest('nested', 'nested-top.css', 'nested--result.css')
+  runImportTest('missing', 'missing.css')
 })


### PR DESCRIPTION
Just remove. Fixes an issue where the inliner would return invalid css (with inlined HTML) if the url of an `@import` directive resolve in a 404 html payload, for example. 
